### PR TITLE
Change dependency scope to compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,13 +42,11 @@
             <groupId>com.github.dhis2.dhis2-core</groupId>
             <artifactId>dhis-api</artifactId>
             <version>${dhis2.api.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dhis2.dhis2-core</groupId>
             <artifactId>dhis-service-dxf2</artifactId>
             <version>${dhis2.api.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hisp.dhis.parser</groupId>


### PR DESCRIPTION
Change dependency scope to compile so that users don't need to manually include the dependencies when running the tool.