### PR TITLE
Generate opaque schemas for non-Jackson annotated classes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <dhis2.api.version>2.37.6</dhis2.api.version>
         <output.dir>schemas</output.dir>
         <gpg.skip>true</gpg.skip>
+        <junit.version>5.8.2</junit.version>
     </properties>
 
     <dependencies>
@@ -22,6 +23,11 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.10.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.victools</groupId>
@@ -44,11 +50,6 @@
             <version>${dhis2.api.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.dhis2.dhis2-core</groupId>
-            <artifactId>dhis-service-dxf2</artifactId>
-            <version>${dhis2.api.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.hisp.dhis.parser</groupId>
             <artifactId>dhis-antlr-expression-parser</artifactId>
             <version>1.0.26</version>
@@ -62,7 +63,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.2</version>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -75,6 +82,27 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <requireReleaseDeps>
+                                    <onlyWhenRelease>true</onlyWhenRelease>
+                                    <message>No Snapshots Allowed!</message>
+                                </requireReleaseDeps>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/src/main/java/org/hisp/dhis/integration/jsonschemagen/DateStringFormatResolver.java
+++ b/src/main/java/org/hisp/dhis/integration/jsonschemagen/DateStringFormatResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.integration.jsonschemagen;
+
+import java.util.Date;
+
+import com.github.victools.jsonschema.generator.ConfigFunction;
+import com.github.victools.jsonschema.generator.TypeScope;
+
+public class DateStringFormatResolver implements ConfigFunction<TypeScope, String>
+{
+    @Override
+    public String apply( TypeScope target )
+    {
+        if ( target.getType().getErasedType().equals( Date.class ) )
+        {
+            return "date-time";
+        }
+        else
+        {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/hisp/dhis/integration/jsonschemagen/Dhis2JsonSchemaGenerator.java
+++ b/src/main/java/org/hisp/dhis/integration/jsonschemagen/Dhis2JsonSchemaGenerator.java
@@ -29,10 +29,9 @@ package org.hisp.dhis.integration.jsonschemagen;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -63,7 +62,8 @@ public final class Dhis2JsonSchemaGenerator
     }
 
     public static void main( String[] args )
-        throws IOException
+        throws IOException,
+        URISyntaxException
     {
         String outputDestinationDir = args[0];
 
@@ -77,19 +77,11 @@ public final class Dhis2JsonSchemaGenerator
 
         JacksonModule jacksonModule = new JacksonModule( JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS,
             JacksonOption.RESPECT_JSONPROPERTY_REQUIRED );
+
         for ( Class<?> apiClass : apiClasses )
         {
-            generateJsonSchema( apiClass, jacksonModule, true, outputDestinationDir );
+            generateJsonSchema( apiClass, jacksonModule, outputDestinationDir );
         }
-
-        generateJsonSchema( getClassOrNull( "org.locationtech.jts.geom.Geometry" ), jacksonModule, false,
-            outputDestinationDir );
-        generateJsonSchema( getClassOrNull( "org.hisp.dhis.common.DimensionalItemObject" ), jacksonModule, false,
-            outputDestinationDir );
-        generateJsonSchema( getClassOrNull( "org.hisp.dhis.common.DimensionalObject" ), jacksonModule, false,
-            outputDestinationDir );
-        generateJsonSchema( getClassOrNull( "org.hisp.dhis.common.DimensionItemKeywords" ), jacksonModule, false,
-            outputDestinationDir );
     }
 
     static List<Class<?>> prepare( Set<Class<?>>... types )
@@ -102,24 +94,13 @@ public final class Dhis2JsonSchemaGenerator
 
         return apiClasses.stream()
             .filter( a -> !(a.getName().startsWith( "com.fasterxml" ) || a.getName()
-                .startsWith( "org.hisp.dhis.schema.annotation.Property" )) ).sorted(Comparator.comparing( Class::getName ))
+                .startsWith( "org.hisp.dhis.schema.annotation.Property" )) )
+            .sorted( Comparator.comparing( Class::getName ) )
             .collect( Collectors.toList() );
     }
 
-    private static Class<?> getClassOrNull( String className )
-    {
-        try
-        {
-            return Class.forName( className );
-        }
-        catch ( ClassNotFoundException e )
-        {
-            return null;
-        }
-    }
-
     private static void generateJsonSchema( Class<?> apiClass, JacksonModule jacksonModule,
-        boolean discardEmptySchemas, String outputDestinationDir )
+        String outputDestinationDir )
         throws IOException
     {
         if ( apiClass == null )
@@ -127,84 +108,37 @@ public final class Dhis2JsonSchemaGenerator
             return;
         }
 
-        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(
-            SchemaVersion.DRAFT_2019_09,
+        SchemaGeneratorConfigBuilder schemaGeneratorConfigBuilder = new SchemaGeneratorConfigBuilder(
+            SchemaVersion.DRAFT_2020_12,
             OptionPreset.PLAIN_JSON )
-            .with( jacksonModule )
-            .with( Option.PLAIN_DEFINITION_KEYS, Option.GETTER_METHODS, Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES,
-                Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS, Option.NONSTATIC_NONVOID_NONGETTER_METHODS )
-            .without( Option.NONPUBLIC_NONSTATIC_FIELDS_WITH_GETTERS, Option.EXTRA_OPEN_API_FORMAT_VALUES );
+                .with( jacksonModule )
+                .with( Option.PLAIN_DEFINITION_KEYS, Option.GETTER_METHODS, Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES,
+                    Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS, Option.NONSTATIC_NONVOID_NONGETTER_METHODS )
+                .without( Option.NONPUBLIC_NONSTATIC_FIELDS_WITH_GETTERS, Option.EXTRA_OPEN_API_FORMAT_VALUES );
 
-        configBuilder.forTypesInGeneral().withStringFormatResolver( target -> {
-            if ( target.getType().getErasedType().equals( Date.class ) )
-            {
-                return "date-time";
-            }
-            else
-            {
-                return null;
-            }
-        } ).withCustomDefinitionProvider( new RefDefinitionProvider( apiClass ) );
-        configBuilder.forFields()
+        schemaGeneratorConfigBuilder.forTypesInGeneral().withStringFormatResolver( new DateStringFormatResolver() )
+            .withCustomDefinitionProvider( new RefDefinitionProvider( apiClass ) );
+        schemaGeneratorConfigBuilder.forFields()
             .withIgnoreCheck( fieldScope -> fieldScope.getAnnotation( JsonProperty.class ) == null );
 
-        SchemaGeneratorConfig config = configBuilder.build();
-        SchemaGenerator generator = new SchemaGenerator( config,
-            TypeContextFactory.createTypeContext( AnnotationInclusion.INCLUDE_AND_INHERIT, config ) );
-        ObjectNode jsonSchema = generator.generateSchema( apiClass );
+        SchemaGeneratorConfig schemaGeneratorConfig = schemaGeneratorConfigBuilder.build();
+        SchemaGenerator schemaGenerator = new SchemaGenerator( schemaGeneratorConfig,
+            TypeContextFactory.createTypeContext( AnnotationInclusion.INCLUDE_AND_INHERIT, schemaGeneratorConfig ) );
+        ObjectNode jsonSchema = schemaGenerator.generateSchema( apiClass );
 
-        Set<Class<?>> includedApiClasses = new HashSet<>();
-        includeApiClass( "org.hisp.dhis.sms.outbound.BulkSmsRecipient", includedApiClasses );
-        includeApiClass( "org.hisp.dhis.period.PeriodType", includedApiClasses );
-        includeApiClass( "org.hisp.dhis.dxf2.webmessage.WebMessageResponse", includedApiClasses );
-        includeApiClass( "org.hisp.dhis.common.IdSchemes", includedApiClasses );
-        includeApiClass( "org.hisp.dhis.scheduling.JobParameters", includedApiClasses );
-        includeApiClass( "org.hisp.dhis.common.NameableObject", includedApiClasses );
-
-        if ( !discardEmptySchemas || Map.class.isAssignableFrom( apiClass ) || includedApiClasses.contains( apiClass )
-            || jsonSchema.get( "const" ) != null
-            || jsonSchema.get( "enum" ) != null
-            || jsonSchema.get( "properties" ) != null )
+        if ( RefToTypeMapping.getInstance().containsValue( apiClass ) )
         {
             String filename = null;
-            if ( RefToTypeMapping.getInstance().containsValue( apiClass ) )
+            for ( Map.Entry<String, Class<?>> mapping : RefToTypeMapping.getInstance().entrySet() )
             {
+                if ( mapping.getValue().equals( apiClass ) )
+                {
+                    filename = mapping.getKey();
+                }
+            }
 
-                for ( Map.Entry<String, Class<?>> mapping : RefToTypeMapping.getInstance().entrySet() )
-                {
-                    if ( mapping.getValue().equals( apiClass ) )
-                    {
-                        filename = mapping.getKey();
-                    }
-                }
-            }
-            else
-            {
-                int repeat = 0;
-                while ( filename == null || (RefToTypeMapping.getInstance().get( filename ) != null) )
-                {
-                    filename = apiClass.getSimpleName().substring( 0, 1 )
-                        .toLowerCase()
-                        + apiClass.getSimpleName().substring( 1 )
-                        + "_".repeat( repeat ) + ".json";
-                    repeat++;
-                }
-                RefToTypeMapping.getInstance().put( filename, apiClass );
-            }
             FileUtils.writeStringToFile( new File( outputDestinationDir + "/" + filename ), jsonSchema.toPrettyString(),
                 "UTF-8" );
-        }
-    }
-
-    private static void includeApiClass( String apiClassName, Set<Class<?>> includedApiClasses )
-    {
-        try
-        {
-            includedApiClasses.add( Class.forName( apiClassName ) );
-        }
-        catch ( ClassNotFoundException ignored )
-        {
-
         }
     }
 }

--- a/src/test/java/org/hisp/dhis/integration/jsonschemagen/Dhis2JsonSchemaGeneratorTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/jsonschemagen/Dhis2JsonSchemaGeneratorTestCase.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,6 +42,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
 import org.jsonschema2pojo.DefaultGenerationConfig;
@@ -60,22 +62,23 @@ import com.sun.codemodel.JCodeModel;
 
 public class Dhis2JsonSchemaGeneratorTestCase
 {
-    private File generatedTestResourcesDir;
+    private File generatedSchemasDir;
 
     @BeforeEach
     public void beforeEach()
-        throws IOException
+        throws IOException,
+        URISyntaxException
     {
         Dhis2JsonSchemaGenerator.main( new String[] { "target/generated-test-resources" } );
-        generatedTestResourcesDir = new File( "target/generated-test-resources" );
-        assertTrue( generatedTestResourcesDir.list().length > 0 );
+        generatedSchemasDir = new File( "target/generated-test-resources" );
+        assertTrue( generatedSchemasDir.list().length > 0 );
     }
 
     @AfterEach
     public void afterEach()
         throws IOException
     {
-        generatedTestResourcesDir.delete();
+        generatedSchemasDir.delete();
     }
 
     @Test
@@ -117,6 +120,18 @@ public class Dhis2JsonSchemaGeneratorTestCase
     {
         assertEquals( "string", JsonPath.parse( new File( "target/generated-test-resources/typeReport.json" ) )
             .read( "$.properties.klass.type" ) );
+    }
+
+    @Test
+    public void testSchemaVersion()
+        throws IOException
+    {
+        String jsonSchemaUnderTest = generatedSchemasDir.list()[ThreadLocalRandom.current()
+            .nextInt( 0, generatedSchemasDir.list().length - 1 )];
+
+        assertEquals( "https://json-schema.org/draft/2020-12/schema",
+            JsonPath.parse( new File( "target/generated-test-resources/" + jsonSchemaUnderTest ) )
+                .read( "$.$schema" ) );
     }
 
     @Test

--- a/src/test/java/org/hisp/dhis/integration/jsonschemagen/RefDefinitionProviderTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/jsonschemagen/RefDefinitionProviderTestCase.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.integration.jsonschemagen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.fasterxml.classmate.TypeResolver;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.generator.TypeContext;
+import com.github.victools.jsonschema.generator.impl.SchemaGenerationContextImpl;
+import com.github.victools.jsonschema.generator.impl.TypeContextFactory;
+
+public class RefDefinitionProviderTestCase
+{
+    private SchemaGenerationContextImpl schemaGenerationContext;
+
+    @BeforeEach
+    public void beforeEach()
+    {
+        SchemaGeneratorConfig schemaGeneratorConfig = new SchemaGeneratorConfigBuilder(
+            SchemaVersion.DRAFT_2020_12 ).build();
+        TypeContext typeContext = TypeContextFactory.createDefaultTypeContext(
+            new SchemaGeneratorConfigBuilder( SchemaVersion.DRAFT_2020_12 ).build() );
+        schemaGenerationContext = new SchemaGenerationContextImpl( schemaGeneratorConfig,
+            typeContext );
+    }
+
+    @AfterEach
+    public void afterEach()
+    {
+        RefToTypeMapping.getInstance().clear();
+    }
+
+    @ParameterizedTest
+    @ValueSource( classes = { Date.class, Set.class, List.class, String.class, Boolean.class, Byte.class,
+        Character.class, Short.class, Integer.class, Long.class, Double.class, Float.class, Void.class } )
+    public void testProvideCustomSchemaDefinitionReturnsNullGivenResolvedTypeIsJavaDataType( Class<?> clazz )
+    {
+
+        RefDefinitionProvider refDefinitionProvider = new RefDefinitionProvider( clazz );
+
+        assertNull( refDefinitionProvider.provideCustomSchemaDefinition(
+            new TypeResolver().resolve( clazz ), schemaGenerationContext ) );
+    }
+
+    @Test
+    public void testProvideCustomSchemaDefinitionReturnsInternalCommentGivenResolvedTypeIsNotJavaDataTypeAndNotJacksonAnnotated()
+    {
+        RefDefinitionProvider refDefinitionProvider = new RefDefinitionProvider( Map.class );
+
+        CustomDefinition customDefinition = refDefinitionProvider.provideCustomSchemaDefinition(
+            new TypeResolver().resolve( Map.class ), schemaGenerationContext );
+        assertEquals( "For internal use only", customDefinition.getValue().get( "$comment" ).asText() );
+    }
+
+    @ParameterizedTest
+    @ValueSource( classes = { JsonPropertyFieldClass.class, JacksonXmlRootElementClass.class,
+        JsonPropertyMethodClass.class } )
+    public void testProvideCustomSchemaDefinitionReturnsNullGivenResolvedTypeIsJacksonAnnotatedAndIsEqualToApiClass(
+        Class<?> clazz )
+    {
+        RefDefinitionProvider refDefinitionProvider = new RefDefinitionProvider( clazz );
+
+        assertFalse( RefToTypeMapping.getInstance().containsValue( clazz ) );
+        assertNull( refDefinitionProvider.provideCustomSchemaDefinition(
+            new TypeResolver().resolve( clazz ), schemaGenerationContext ) );
+        assertTrue( RefToTypeMapping.getInstance().containsValue( clazz ) );
+    }
+
+    @ParameterizedTest
+    @ValueSource( classes = { JsonPropertyFieldClass.class, JacksonXmlRootElementClass.class,
+        JsonPropertyMethodClass.class } )
+    public void testProvideCustomSchemaDefinitionReturnsCustomDefinitionGivenResolvedTypeIsJacksonAnnotatedButNotEqualToApiClass(
+        Class<?> clazz )
+    {
+        RefDefinitionProvider refDefinitionProvider = new RefDefinitionProvider( RootClass.class );
+
+        assertFalse( RefToTypeMapping.getInstance().containsValue( clazz ) );
+        CustomDefinition customDefinition = refDefinitionProvider.provideCustomSchemaDefinition(
+            new TypeResolver().resolve( clazz ), schemaGenerationContext );
+        assertNotNull( customDefinition );
+        assertNull( customDefinition.getValue().get( "$comment" ) );
+        assertTrue( RefToTypeMapping.getInstance().containsValue( clazz ) );
+    }
+
+    @JacksonXmlRootElement
+    public static class JacksonXmlRootElementClass
+    {
+
+    }
+
+    public static class JsonPropertyFieldClass
+    {
+        @JsonProperty
+        private String field;
+    }
+
+    public static class JsonPropertyMethodClass
+    {
+        @JsonProperty
+        private void getMethod()
+        {
+
+        }
+    }
+
+    public static class RootClass
+    {
+    }
+}

--- a/src/test/java/org/hisp/dhis/integration/jsonschemagen/RefDefinitionProviderTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/jsonschemagen/RefDefinitionProviderTestCase.java
@@ -62,6 +62,7 @@ public class RefDefinitionProviderTestCase
     @BeforeEach
     public void beforeEach()
     {
+        RefToTypeMapping.getInstance().clear();
         SchemaGeneratorConfig schemaGeneratorConfig = new SchemaGeneratorConfigBuilder(
             SchemaVersion.DRAFT_2020_12 ).build();
         TypeContext typeContext = TypeContextFactory.createDefaultTypeContext(


### PR DESCRIPTION
Don't introspect non-Jackson annotated classes and instead generate inline object schemas without any properties so that (1) a lot of corner cases can be dropped from the code and (2) implementation-specific schemas like `LinkedHashMap.json` are not generated.