### PR TITLE
Drop assumption that non-Jackson annotated non-Java data types will always be complex

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
             <version>${dhis2.api.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.dhis2.dhis2-core</groupId>
+            <artifactId>dhis-service-dxf2</artifactId>
+            <version>${dhis2.api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.hisp.dhis.parser</groupId>
             <artifactId>dhis-antlr-expression-parser</artifactId>
             <version>1.0.26</version>

--- a/src/test/java/org/hisp/dhis/integration/jsonschemagen/RefDefinitionProviderTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/jsonschemagen/RefDefinitionProviderTestCase.java
@@ -90,13 +90,36 @@ public class RefDefinitionProviderTestCase
     }
 
     @Test
-    public void testProvideCustomSchemaDefinitionReturnsInternalCommentGivenResolvedTypeIsNotJavaDataTypeAndNotJacksonAnnotated()
+    public void testProvideCustomSchemaDefinitionReturnsUndefinedCommentGivenResolvedTypeIsMapAndIsNotJacksonAnnotated()
     {
         RefDefinitionProvider refDefinitionProvider = new RefDefinitionProvider( Map.class );
 
         CustomDefinition customDefinition = refDefinitionProvider.provideCustomSchemaDefinition(
             new TypeResolver().resolve( Map.class ), schemaGenerationContext );
-        assertEquals( "For internal use only", customDefinition.getValue().get( "$comment" ).asText() );
+        assertEquals( "object", customDefinition.getValue().get( "type" ).asText() );
+        assertEquals( "Undefined", customDefinition.getValue().get( "$comment" ).asText() );
+    }
+
+    @Test
+    public void testProvideCustomSchemaDefinitionReturnsUndefinedCommentGivenResolvedTypeIsIterableAndIsNotJacksonAnnotated()
+    {
+        RefDefinitionProvider refDefinitionProvider = new RefDefinitionProvider( Iterable.class );
+
+        CustomDefinition customDefinition = refDefinitionProvider.provideCustomSchemaDefinition(
+            new TypeResolver().resolve( Iterable.class ), schemaGenerationContext );
+        assertEquals( "array", customDefinition.getValue().get( "type" ).asText() );
+        assertEquals( "Undefined", customDefinition.getValue().get( "$comment" ).asText() );
+    }
+
+    @Test
+    public void testProvideCustomSchemaDefinitionReturnsUndefinedCommentGivenResolvedTypeIsNotIterableAndIsNotMapAndIsNotJacksonAnnotated()
+    {
+        RefDefinitionProvider refDefinitionProvider = new RefDefinitionProvider( List.class );
+
+        CustomDefinition customDefinition = refDefinitionProvider.provideCustomSchemaDefinition(
+            new TypeResolver().resolve( Object.class ), schemaGenerationContext );
+        assertNotNull( customDefinition.getValue().get( "anyOf" ) );
+        assertEquals( "Undefined", customDefinition.getValue().get( "$comment" ).asText() );
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Drop assumption that non-Jackson annotated non-Java data types will always be complex.