### PR TITLE
Add dhis-service-tracker as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
             <version>${dhis2.api.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.dhis2.dhis2-core</groupId>
+            <artifactId>dhis-service-tracker</artifactId>
+            <version>${dhis2.api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.hisp.dhis.parser</groupId>
             <artifactId>dhis-antlr-expression-parser</artifactId>
             <version>1.0.26</version>


### PR DESCRIPTION
Add `dhis-service-tracker` as a dependency since it doesn't seem to be transitive for some API versions which is causing a no. of JSON schemas not be generated.