### PR TITLE
Treat classes which are only annotated with JacksonXmlRootElement as undefined

### DIFF
--- a/src/main/java/org/hisp/dhis/integration/jsonschemagen/internal/RefDefinitionProvider.java
+++ b/src/main/java/org/hisp/dhis/integration/jsonschemagen/internal/RefDefinitionProvider.java
@@ -100,12 +100,6 @@ public class RefDefinitionProvider implements CustomDefinitionProviderV2
             {
                 SchemaGeneratorConfig schemaGeneratorConfig = context.getGeneratorConfig();
                 ObjectNode customNode = schemaGeneratorConfig.createObjectNode();
-                customNode.set( context.getKeyword( SchemaKeyword.TAG_ANYOF ), schemaGeneratorConfig.createArrayNode()
-                    .add( schemaGeneratorConfig.createObjectNode().put( context.getKeyword( SchemaKeyword.TAG_TYPE ),
-                        context.getKeyword( SchemaKeyword.TAG_TYPE_ARRAY ) ) )
-                    .add( schemaGeneratorConfig.createObjectNode().put( context.getKeyword( SchemaKeyword.TAG_TYPE ),
-                        context.getKeyword( SchemaKeyword.TAG_TYPE_OBJECT ) ) ) );
-
                 customDefinition = new CustomDefinition( customNode,
                     CustomDefinition.DefinitionType.INLINE,
                     CustomDefinition.AttributeInclusion.YES );
@@ -170,10 +164,10 @@ public class RefDefinitionProvider implements CustomDefinitionProviderV2
             return false;
         }
 
-        if ( javaType.getErasedType().isAnnotationPresent( JacksonXmlRootElement.class ) )
-        {
-            return false;
-        }
+//        if ( javaType.getErasedType().isAnnotationPresent( JacksonXmlRootElement.class ) )
+//        {
+//            return false;
+//        }
 
         for ( RawField memberField : javaType.getMemberFields() )
         {

--- a/src/main/java/org/hisp/dhis/integration/jsonschemagen/internal/RefDefinitionProvider.java
+++ b/src/main/java/org/hisp/dhis/integration/jsonschemagen/internal/RefDefinitionProvider.java
@@ -164,11 +164,6 @@ public class RefDefinitionProvider implements CustomDefinitionProviderV2
             return false;
         }
 
-//        if ( javaType.getErasedType().isAnnotationPresent( JacksonXmlRootElement.class ) )
-//        {
-//            return false;
-//        }
-
         for ( RawField memberField : javaType.getMemberFields() )
         {
             if ( memberField.getRawMember().isAnnotationPresent( JsonProperty.class ) )

--- a/src/test/java/org/hisp/dhis/integration/jsonschemagen/internal/RefDefinitionProviderTestCase.java
+++ b/src/test/java/org/hisp/dhis/integration/jsonschemagen/internal/RefDefinitionProviderTestCase.java
@@ -103,6 +103,17 @@ public class RefDefinitionProviderTestCase
     }
 
     @Test
+    public void testProvideCustomSchemaDefinitionReturnsUndefinedCommentGivenResolvedTypeIsOnlyJacksonXmlRootElementAnnotated()
+    {
+        RefDefinitionProvider refDefinitionProvider = new RefDefinitionProvider( JacksonXmlRootElementClass.class );
+
+        CustomDefinition customDefinition = refDefinitionProvider.provideCustomSchemaDefinition(
+            new TypeResolver().resolve( Map.class ), schemaGenerationContext );
+        assertEquals( "object", customDefinition.getValue().get( "type" ).asText() );
+        assertEquals( "Undefined", customDefinition.getValue().get( "$comment" ).asText() );
+    }
+
+    @Test
     public void testProvideCustomSchemaDefinitionReturnsUndefinedCommentGivenResolvedTypeIsIterableAndIsNotJacksonAnnotated()
     {
         RefDefinitionProvider refDefinitionProvider = new RefDefinitionProvider( Iterable.class );
@@ -120,13 +131,11 @@ public class RefDefinitionProviderTestCase
 
         CustomDefinition customDefinition = refDefinitionProvider.provideCustomSchemaDefinition(
             new TypeResolver().resolve( Object.class ), schemaGenerationContext );
-        assertNotNull( customDefinition.getValue().get( "anyOf" ) );
         assertEquals( "Undefined", customDefinition.getValue().get( "$comment" ).asText() );
     }
 
     @ParameterizedTest
-    @ValueSource( classes = { JsonPropertyFieldClass.class, JacksonXmlRootElementClass.class,
-        JsonPropertyMethodClass.class } )
+    @ValueSource( classes = { JsonPropertyFieldClass.class, JsonPropertyMethodClass.class } )
     public void testProvideCustomSchemaDefinitionReturnsNullGivenResolvedTypeIsJacksonAnnotatedAndIsEqualToApiClass(
         Class<?> clazz )
     {
@@ -139,8 +148,7 @@ public class RefDefinitionProviderTestCase
     }
 
     @ParameterizedTest
-    @ValueSource( classes = { JsonPropertyFieldClass.class, JacksonXmlRootElementClass.class,
-        JsonPropertyMethodClass.class } )
+    @ValueSource( classes = { JsonPropertyFieldClass.class, JsonPropertyMethodClass.class } )
     public void testProvideCustomSchemaDefinitionReturnsCustomDefinitionGivenResolvedTypeIsJacksonAnnotatedButNotEqualToApiClass(
         Class<?> clazz )
     {


### PR DESCRIPTION
Treat classes which are only annotated with JacksonXmlRootElement as undefined since it can't be inferred whether the type is simple like string or complex like object